### PR TITLE
fix: Fix warning on FreeBSD

### DIFF
--- a/sw
+++ b/sw
@@ -18,7 +18,7 @@ trap finish EXIT
 # Use GNU date if possible as it's most likely to have nanoseconds available.
 if hash gdate 2>/dev/null; then
     GNU_DATE=gdate
-elif date --version | grep 'GNU coreutils' >/dev/null; then
+elif date --version 2> /dev/null | grep 'GNU coreutils' >/dev/null; then
     GNU_DATE=date
 fi
 


### PR DESCRIPTION
FreeBSD's `date` command does not have a `--version` option and therefore prints an error during the version detection:

```sh
# sw
date: illegal option -- -
usage: date [-jnRu] [-I[date|hours|minutes|seconds]] [-f input_fmt]
            [ -z output_zone ] [-r filename|seconds] [-v[+|-]val[y|m|w|d|H|M|S]]
            [[[[[[cc]yy]mm]dd]HH]MM[.SS] | new_date] [+output_fmt]
0:00:01^C
```

This can be easily fixed by sending stderr to /dev/null.